### PR TITLE
Fix the NPE by putting primitive values instead of the parcelable

### DIFF
--- a/Application/src/main/java/com/example/android/directboot/alarms/AlarmIntentService.java
+++ b/Application/src/main/java/com/example/android/directboot/alarms/AlarmIntentService.java
@@ -23,6 +23,7 @@ import android.app.Notification;
 import android.app.NotificationManager;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Bundle;
 import android.provider.Settings;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.content.LocalBroadcastManager;
@@ -43,7 +44,15 @@ public class AlarmIntentService extends IntentService {
     @Override
     protected void onHandleIntent(Intent intent) {
         Context context = getApplicationContext();
-        Alarm alarm = intent.getParcelableExtra(ALARM_KEY);
+        // TODO: For some reasons, parcelable serialization started to fail in IntentService
+        //       Retrieving primitives from the intent as a workaround
+        Alarm alarm = new Alarm();
+        Bundle bundle = intent.getExtras();
+        alarm.id = bundle.getInt("id");
+        alarm.minute = bundle.getInt("minute");
+        alarm.hour = bundle.getInt("hour");
+        alarm.date = bundle.getInt("date");
+        alarm.month = bundle.getInt("month");
 
         NotificationManager notificationManager = context
                 .getSystemService(NotificationManager.class);

--- a/Application/src/main/java/com/example/android/directboot/alarms/AlarmUtil.java
+++ b/Application/src/main/java/com/example/android/directboot/alarms/AlarmUtil.java
@@ -45,7 +45,13 @@ public class AlarmUtil {
      */
     public void scheduleAlarm(Alarm alarm) {
         Intent intent = new Intent(mContext, AlarmIntentService.class);
-        intent.putExtra(AlarmIntentService.ALARM_KEY, alarm);
+        // TODO: For some reasons, a parcelable serialization started to fail in IntentService
+        //       As a workaround, putting primitives in the intent
+        intent.putExtra("id", alarm.id);
+        intent.putExtra("minute", alarm.minute);
+        intent.putExtra("hour", alarm.hour);
+        intent.putExtra("date", alarm.date);
+        intent.putExtra("month", alarm.month);
         PendingIntent pendingIntent = PendingIntent
                 .getService(mContext, alarm.id, intent, PendingIntent.FLAG_UPDATE_CURRENT);
         Calendar alarmTime = Calendar.getInstance();
@@ -61,7 +67,7 @@ public class AlarmUtil {
         Log.i(TAG,
                 String.format("Alarm scheduled at (%2d:%02d) Date: %d, Month: %d",
                         alarm.hour, alarm.minute,
-                        alarm.month, alarm.date));
+                        alarm.date, alarm.month));
     }
 
     /**


### PR DESCRIPTION
(Alarm instance)

For some reasons, serialization for the parcelble started to fail since some
point. This is a workaround to avoid NPE.
